### PR TITLE
Add exports for initLogger/flushLogger to use without main

### DIFF
--- a/src/Control/Logger/Simple.hs
+++ b/src/Control/Logger/Simple.hs
@@ -9,7 +9,7 @@ module Control.Logger.Simple
     , pureTrace, pureDebug, pureInfo, pureNote, pureWarn, pureError
     , showText, (<>)
     , monadLoggerAdapter, runSimpleLoggingT
-    , initLogger, flushLogger
+    , Loggers, initLogger, flushLogger
     )
 where
 


### PR DESCRIPTION
You don't have a `main` when exporting for FFI, so the bracket parts have to be executed manually.